### PR TITLE
Move licensing information below xml definition in xml files

### DIFF
--- a/site/components/categories/global-categories.xml
+++ b/site/components/categories/global-categories.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/categories</content-type>	<display-template>/templates/web/components/categories.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/footers/global-footer.xml
+++ b/site/components/footers/global-footer.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/footer</content-type>	<display-template>/templates/web/components/footer.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/headers/global-header.xml
+++ b/site/components/headers/global-header.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/header</content-type>	<display-template>/templates/web/components/header.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/headers/mobile-navigation.xml
+++ b/site/components/headers/mobile-navigation.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/mobile-navigation</content-type>	<display-template>/templates/web/components/mobile-nav.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/right-rails/global-right-rail.xml
+++ b/site/components/right-rails/global-right-rail.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/right-rail</content-type>	<display-template>/templates/web/components/right-rail.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/social-media-links/global-social-media-links.xml
+++ b/site/components/social-media-links/global-social-media-links.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/social-media-links</content-type>	<display-template>/templates/web/components/social-medial-links.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/tags/global-tags.xml
+++ b/site/components/tags/global-tags.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/tags</content-type>	<display-template>/templates/web/components/tags.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/video-sections/most-viewed-videos-section.xml
+++ b/site/components/video-sections/most-viewed-videos-section.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video-section</content-type>	<display-template>/templates/web/components/video-section.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/video-sections/newest-videos-section.xml
+++ b/site/components/video-sections/newest-videos-section.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video-section</content-type>	<display-template>/templates/web/components/video-section.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/video-sections/streams-section.xml
+++ b/site/components/video-sections/streams-section.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video-section</content-type>	<display-template>/templates/web/components/video-section.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/components/video-widgets/recent-videos-widget.xml
+++ b/site/components/video-widgets/recent-videos-widget.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video-widget</content-type>	<display-template>/templates/web/components/video-widget.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/origins/b813b916-3238-ed76-1314-230e1b94eb9f.xml
+++ b/site/origins/b813b916-3238-ed76-1314-230e1b94eb9f.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/stream-origin</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/streams/2bbf23cf-952a-8a54-9b01-b25ae8b4a4b5.xml
+++ b/site/streams/2bbf23cf-952a-8a54-9b01-b25ae8b4a4b5.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/stream</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/taxonomies/categories.xml
+++ b/site/taxonomies/categories.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/taxonomy</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/taxonomies/encodings.xml
+++ b/site/taxonomies/encodings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/taxonomy</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/taxonomies/grid-styles.xml
+++ b/site/taxonomies/grid-styles.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/taxonomy</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/taxonomies/icons.xml
+++ b/site/taxonomies/icons.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/taxonomy</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/taxonomies/social-media-types.xml
+++ b/site/taxonomies/social-media-types.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/taxonomy</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/2017-mcas-miramar-air-show--blue-angels.xml
+++ b/site/videos/2017-mcas-miramar-air-show--blue-angels.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/2nd-medical-battalion-conducts-certification-exercise.xml
+++ b/site/videos/2nd-medical-battalion-conducts-certification-exercise.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/afnow-hurricane-harvey.xml
+++ b/site/videos/afnow-hurricane-harvey.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/afnow-the-future-of-space.xml
+++ b/site/videos/afnow-the-future-of-space.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/americas-strategic-bombers.xml
+++ b/site/videos/americas-strategic-bombers.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/army-combatives-program.xml
+++ b/site/videos/army-combatives-program.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/bastille-day.xml
+++ b/site/videos/bastille-day.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/buffalo-soldiers.xml
+++ b/site/videos/buffalo-soldiers.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/changing-of-the-guard-ceremony.xml
+++ b/site/videos/changing-of-the-guard-ceremony.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/d-day-to-v-e-day.xml
+++ b/site/videos/d-day-to-v-e-day.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/darpa-funded-program-may-help-future-soldiers.xml
+++ b/site/videos/darpa-funded-program-may-help-future-soldiers.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/immersive-virtual-shipboard-environment-trains-sailors.xml
+++ b/site/videos/immersive-virtual-shipboard-environment-trains-sailors.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/jungle-warfare-school.xml
+++ b/site/videos/jungle-warfare-school.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/leadership-short-secretary-of-the-air-force-a-bomber-for-the-21st-century.xml
+++ b/site/videos/leadership-short-secretary-of-the-air-force-a-bomber-for-the-21st-century.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/videos/new-test-dummies-join-army-team.xml
+++ b/site/videos/new-test-dummies-join-army-team.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/video</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/about-us/index.xml
+++ b/site/website/about-us/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/generic</content-type>	<display-template>/templates/web/pages/generic.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/account/index.xml
+++ b/site/website/account/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/account</content-type>	<display-template>/templates/web/pages/profile.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/all-videos/index.xml
+++ b/site/website/all-videos/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/all-videos</content-type>	<display-template>/templates/web/pages/video-list.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/category/index.xml
+++ b/site/website/category/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/category-landing</content-type>	<display-template>/templates/web/pages/video-list.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/crafter-component.xml
+++ b/site/website/crafter-component.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page xmlns:alf="http://www.alfresco.org" xmlns:chiba="http://chiba.sourceforge.net/xforms"
               xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xf="http://www.w3.org/2002/xforms"
               xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema"

--- a/site/website/crafter-level-descriptor.level.xml
+++ b/site/website/crafter-level-descriptor.level.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <component>
 	<content-type>/component/level-descriptor</content-type>	<display-template/>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/index.xml
+++ b/site/website/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/home</content-type>	<display-template>/templates/web/pages/home.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/live/index.xml
+++ b/site/website/live/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/live</content-type>	<display-template>/templates/web/pages/live.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/login/index.xml
+++ b/site/website/login/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/login</content-type>	<display-template>/templates/web/pages/login.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/register/index.xml
+++ b/site/website/register/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/register</content-type>	<display-template>/templates/web/pages/register.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/search/index.xml
+++ b/site/website/search/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/search</content-type>	<display-template>/templates/web/pages/search.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/tag/index.xml
+++ b/site/website/tag/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/tag-landing</content-type>	<display-template>/templates/web/pages/video-list.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/terms-and-conditions/index.xml
+++ b/site/website/terms-and-conditions/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/generic</content-type>	<display-template>/templates/web/pages/generic.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>

--- a/site/website/video/index.xml
+++ b/site/website/video/index.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
  MIT License
  
@@ -21,8 +22,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  -->
-
-<?xml version="1.0" encoding="UTF-8"?>
+ 
 <page>
 	<content-type>/page/video</content-type>	<display-template>/templates/web/pages/video.ftl</display-template>
 	<merge-strategy>inherit-levels</merge-strategy>


### PR DESCRIPTION
Licensing information is not allowing xml files to be read correctly. Comments in xml files must appear after the xml file definition.